### PR TITLE
增加静默启动；修复断网导致主进程终止bug

### DIFF
--- a/HustNetwork_GUI.py
+++ b/HustNetwork_GUI.py
@@ -12,6 +12,7 @@ import subprocess
 import requests
 from PySide6 import QtCore, QtWidgets, QtGui
 
+import configparser
 import rc_icon
 
 
@@ -24,21 +25,20 @@ def remove_readonly(func, path, _):
 class HustNetwork(QtCore.QThread):
     status_signal = QtCore.Signal(str)
 
-    def __init__(self, username='', password='', ping_interval=15, ping_dns1='202.114.0.242', ping_dns2='223.5.5.5', config_file=None):
+    def __init__(self, username='', password='', ping_interval=15, ping_dns1='202.114.0.242', ping_dns2='223.5.5.5', config=None):
         super().__init__()
-        if config_file is None:
+        if config is None:
             self._username = username
             self._password = password
             self._ping_interval = ping_interval
             self._ping_dns1 = ping_dns1
             self._ping_dns2 = ping_dns2
         else:
-            with open(config_file, 'r') as f:
-                self._username = f.readline().strip()
-                self._password = f.readline().strip()
-                self._ping_interval = int(f.readline().strip())
-                self._ping_dns1 = f.readline().strip()
-                self._ping_dns2 = f.readline().strip()
+            self._username = config.get('network', 'username')
+            self._password = config.get('network', 'password')
+            self._ping_interval = config.getint('network', 'ping_interval')
+            self._ping_dns1 = config.get('network', 'ping_dns1')
+            self._ping_dns2 = config.get('network', 'ping_dns2')
         self._auth_url = None
         self._referer = None
         self._origin = None
@@ -116,7 +116,10 @@ class HustNetwork(QtCore.QThread):
                 time.sleep(5)
                 continue
             if not ping_status:
-                self._reconnection()
+                try:
+                    self._reconnection()
+                except Exception:
+                    self.status_signal.emit("连接失败！")
             else:
                 self.status_signal.emit("已认证！")
             time.sleep(self._ping_interval)
@@ -126,7 +129,8 @@ class HustNetworkGUI(QtWidgets.QWidget):
     def __init__(self):
         super().__init__()
         self.hustNetwork = None
-
+        self.tray_msg = None
+        
         self.setWindowTitle("华科校园网认证服务")
         self.setWindowIcon(QtGui.QIcon(":/icon/network.png"))
         self.setWindowFlags(QtCore.Qt.WindowType.WindowMinimizeButtonHint |
@@ -154,8 +158,11 @@ class HustNetworkGUI(QtWidgets.QWidget):
 
         self.save_config = QtWidgets.QCheckBox("保存配置")
         self.save_config.setChecked(True)
+        self.silent_start = QtWidgets.QCheckBox("静默启动")
+        self.silent_start.setChecked(False)
         self.button = QtWidgets.QPushButton("开启服务")
-        self.layout.addRow(self.save_config, self.button)
+        self.layout.addRow(self.save_config, self.silent_start)
+        self.layout.addRow(self.button)
 
         if QtWidgets.QSystemTrayIcon.isSystemTrayAvailable():
             self.create_tray_icon()
@@ -163,15 +170,26 @@ class HustNetworkGUI(QtWidgets.QWidget):
 
         self.button.clicked.connect(self.daemon_toggle)
 
-        try:
-            with open('.config', 'r') as f:
-                self.username.setText(f.readline().strip())
-                self.password.setText(f.readline().strip())
-                self.ping_interval.setText(f.readline().strip())
-                self.ping_dns1.setText(f.readline().strip())
-                self.ping_dns2.setText(f.readline().strip())
-        except Exception:
-            pass
+        self.config = configparser.ConfigParser()
+        if os.path.exists("config.ini"):
+            self.config.read("config.ini")  # 读取配置文件
+            self.username.setText(self.config.get('network', 'username'))
+            self.password.setText(self.config.get('network', 'password'))
+            self.ping_interval.setText(
+                self.config.get('network', 'ping_interval'))
+            self.ping_dns1.setText(self.config.get('network', 'ping_dns1'))
+            self.ping_dns2.setText(self.config.get('network', 'ping_dns2'))
+            self.silent_start.setChecked(
+                self.config.getboolean('normal', 'silent_start'))
+        else:
+            self.config['network'] = {
+                'username': '',
+                'password': '',
+                'ping_interval': '',
+                'ping_dns1': ''}
+            self.config['normal'] = {'silent_start': ''}
+            with open('config.ini', 'w') as f:
+                self.config.write(f)
 
         # 删除旧的 _MEIxxxxxx 文件夹
         cur_dir = os.path.dirname(sys.argv[0])
@@ -220,37 +238,48 @@ class HustNetworkGUI(QtWidgets.QWidget):
             return
         if self.hustNetwork and QtWidgets.QSystemTrayIcon.isSystemTrayAvailable() and self.tray_icon.isVisible():
             self.hide()
-            self.tray_icon.showMessage("华科校园网认证服务", "隐藏至系统托盘")
+            self.tray_info("隐藏至系统托盘")
             event.ignore()
 
     def changeEvent(self, event):
         # 服务运行后最小化时隐藏
         if self.hustNetwork and self.windowState() == QtCore.Qt.WindowState.WindowMinimized:
             self.hide()
-            self.tray_icon.showMessage("华科校园网认证服务", "隐藏至系统托盘")
+            self.tray_info("隐藏至系统托盘")
         QtWidgets.QWidget.changeEvent(self, event)
 
     @QtCore.Slot()
     def set_status(self, string: str):
         self.status.setText(string)
 
+    @QtCore.Slot()
+    def tray_info(self, string: str):
+        if self.tray_msg != string:
+            self.tray_msg = string
+            self.tray_icon.showMessage("华科校园网认证服务", string)
+
     def save_to_confg_file(self):
         if self.save_config.isChecked():
-            with open('.config', 'w') as f:
-                f.write(self.username.text() + '\n')
-                f.write(self.password.text() + '\n')
-                f.write(self.ping_interval.text() + '\n')
-                f.write(self.ping_dns1.text() + '\n')
-                f.write(self.ping_dns2.text() + '\n')
+            self.config['network'] = {
+                'username': self.username.text(),
+                'password': self.password.text(),
+                'ping_interval': self.ping_interval.text(),
+                'ping_dns1': self.ping_dns1.text(),
+                'ping_dns2': self.ping_dns2.text()}
+            self.config['normal'] = {
+                'silent_start': str(self.silent_start.isChecked())}
+            with open('config.ini', 'w') as f:
+                self.config.write(f)
 
     def start_auth_daemon(self):
         if self.save_config.isChecked():
-            self.hustNetwork = HustNetwork(config_file='.config')
+            self.hustNetwork = HustNetwork(config=self.config)
         else:
             self.hustNetwork = HustNetwork(
                 self.username.text(), self.password.text(), self.ping_interval.text(),
                 self.ping_dns1.text(), self.ping_dns2.text())
         self.hustNetwork.status_signal.connect(self.set_status)
+        self.hustNetwork.status_signal.connect(self.tray_info)
         self.hustNetwork.start()
 
     @QtCore.Slot()
@@ -278,6 +307,10 @@ if __name__ == "__main__":
 
     widget = HustNetworkGUI()
     widget.resize(250, 200)
-    widget.show()
+    if widget.silent_start.isChecked():
+        widget.hide()
+        widget.daemon_toggle()
+    else:
+        widget.show()
 
     sys.exit(app.exec())


### PR DESCRIPTION
你好，感谢你贡献的工具。
在windows11将GUI软件添加到开机启动时，会弹出显示界面。为了省去这一步，增加了GUI界面静默启动的功能。
为了使配置文件方便读写，采用 .ini 文件进行管理。
测试过程中，在断网情况下， HustNetwork 类的 _reconnection 函数会在调用 self._get_auth_url() 时出现错误导致进程终止，因此增加了 try 函数做了简单处理。