### PR TITLE
捕获网络重连中的异常

### DIFF
--- a/HustNetwork_GUI.py
+++ b/HustNetwork_GUI.py
@@ -115,7 +115,10 @@ class HustNetwork(QtCore.QThread):
                 time.sleep(5)
                 continue
             if not ping_status:
-                self._reconnection()
+                try:
+                    self._reconnection()
+                except Exception:
+                    self.status_signal.emit("连接失败！")
             else:
                 self.status_signal.emit("已认证！")
             time.sleep(self._ping_interval)


### PR DESCRIPTION
在断网后，程序执行self._reconnection函数时在self._get_auth_url()这一步出错，导致进程结束。加入try语句简单处理