### PR TITLE
更新test_url以确保能正确获取到auth_url

### DIFF
--- a/HustNetwork.py
+++ b/HustNetwork.py
@@ -43,7 +43,7 @@ class HustNetwork(object):
 
     def _get_auth_url(self):
         # 通过 http 的网站进行跳转
-        test_url = "http://192.168.1.1"
+        test_url = "http://www.baidu.com"
         response = requests.get(test_url, proxies=self._proxies)
         response.encoding = 'utf8'
 

--- a/HustNetwork.py
+++ b/HustNetwork.py
@@ -43,7 +43,7 @@ class HustNetwork(object):
 
     def _get_auth_url(self):
         # 通过 http 的网站进行跳转
-        test_url = "http://www.baidu.com"
+        test_url = "http://1.1.1.1"
         response = requests.get(test_url, proxies=self._proxies)
         response.encoding = 'utf8'
 

--- a/HustNetwork_GUI.py
+++ b/HustNetwork_GUI.py
@@ -63,7 +63,7 @@ class HustNetwork(QtCore.QThread):
 
     def _get_auth_url(self):
         # 通过 http 的网站进行跳转
-        test_url = "http://www.baidu.com"
+        test_url = "http://1.1.1.1"
         response = requests.get(test_url, proxies=self._proxies)
         response.encoding = 'utf8'
 

--- a/HustNetwork_GUI.py
+++ b/HustNetwork_GUI.py
@@ -63,7 +63,7 @@ class HustNetwork(QtCore.QThread):
 
     def _get_auth_url(self):
         # 通过 http 的网站进行跳转
-        test_url = "http://192.168.1.1"
+        test_url = "http://www.baidu.com"
         response = requests.get(test_url, proxies=self._proxies)
         response.encoding = 'utf8'
 


### PR DESCRIPTION
近段时间程序无法正常认证，测试使用原来的test_url，即 http://192.168.1.1 无法自动跳转到auth_url，报HTTP Connection的Exception，更新test_url为 http://www.baidu.com，经测试可以正常跳转获取auth_url。